### PR TITLE
feat: refactor undo-redo to use less memory

### DIFF
--- a/src/components/PropsEditor/index.tsx
+++ b/src/components/PropsEditor/index.tsx
@@ -11,6 +11,7 @@ import { useRender } from '@src/hooks';
 import data from '@src/data';
 import { ElementType } from '@src/types';
 import TextControl from '@components/PropsEditor/controls/TextControl';
+import { rerenderTopMenu } from '@src/pages/Editor/TopMenu';
 
 const PropsEditor = () => {
   const updateAllControls = useRender();
@@ -29,6 +30,7 @@ const PropsEditor = () => {
     }
 
     rerenderElement();
+    rerenderTopMenu();
     if (shouldRerenderAllControls) {
       updateAllControls();
     }

--- a/src/global/element.ts
+++ b/src/global/element.ts
@@ -176,7 +176,7 @@ export const duplicateElement = (
   element: ElementType | null
 ) => {
   history.capture(() => {
-    _duplicateElement(parentElement, element);
+    _duplicateElement(element);
   });
 
   data.refresh();
@@ -184,18 +184,14 @@ export const duplicateElement = (
   return parentElement;
 };
 
-const _duplicateElement = (
-  parentElement: ParentType,
-  element: ElementType | null
-) => {
-  if (!parentElement) return parentElement;
+const _duplicateElement = (element: ElementType | null) => {
+  const parent = element?.getParent();
+  if (!parent) return;
 
-  const index = parentElement.children.indexOf(element as any);
-  const duplicateElement: ElementType & string = JSON.parse(
-    JSON.stringify(element)
-  );
+  const index = parent.children.indexOf(element as any);
+  const duplicateElement: ElementType & string = copyObject(element);
 
   duplicateElement.getParent = () => null;
 
-  _addChildElementAfter(parentElement, duplicateElement, index);
+  _addChildElementAfter(parent, duplicateElement, index);
 };

--- a/src/global/history.ts
+++ b/src/global/history.ts
@@ -10,7 +10,7 @@ const history = {
   push: (prevState: ElementType, currentState: ElementType) =>
     pushToStates(prevState, currentState),
   undo: () => {
-    if (currentIndex < 0) return;
+    if (currentIndex === 0) return;
 
     decrementIndex();
     const state = elementStates[currentIndex];

--- a/src/hooks/useHistory.ts
+++ b/src/hooks/useHistory.ts
@@ -6,8 +6,8 @@ type HistoryType = {
   undo: () => void;
   redo: () => void;
   currentIndex: number;
-  undoIsDisabled: boolean;
-  redoIsDisabled: boolean;
+  canUndo: any;
+  canRedo: any;
 };
 const useHistory = (): HistoryType => {
   const [currentIndex, setCurrentIndex] = useState(history.currentIndex);
@@ -25,9 +25,12 @@ const useHistory = (): HistoryType => {
       renderEditor();
     },
     currentIndex,
-    undoIsDisabled: history.currentIndex < 0 || history.count === 0,
-    redoIsDisabled:
-      history.currentIndex === history.count - 1 || history.count === 0,
+    get canUndo() {
+      return history.currentIndex !== 0;
+    },
+    get canRedo() {
+      return history.currentIndex !== history.count - 1 && history.count > 0;
+    },
   };
 };
 

--- a/src/pages/Editor/ElementContainer/index.tsx
+++ b/src/pages/Editor/ElementContainer/index.tsx
@@ -17,11 +17,11 @@ const Elements = () => {
       </HeadingContainer>
       <StylesGroup>Basic</StylesGroup>
       <S.ElementsContainer>
-        {Object.keys(elements).map((key) => {
+        {Object.keys(elements).map((key, index) => {
           const element = elements[key].data;
           const Icon = elements[key].icon;
           return (
-            <S.ElementBlockWrapper>
+            <S.ElementBlockWrapper key={index}>
               <S.ElementBlock
                 data-testid={generateElementTestId(element)}
                 className="selectable"

--- a/src/pages/Editor/TopMenu/index.tsx
+++ b/src/pages/Editor/TopMenu/index.tsx
@@ -11,8 +11,13 @@ import {
 import useHistory from '@src/hooks/useHistory';
 import Tooltip from '@components/Tooltip';
 import useMapHotkeys from '@src/pages/Editor/TopMenu/useMapHotkeys';
+import { useRender } from '@src/hooks';
+let renderTopMenu: () => void;
 
 const TopMenu = () => {
+  const render = useRender();
+  renderTopMenu = render;
+
   useMapHotkeys();
   const history = useHistory();
 
@@ -59,3 +64,7 @@ const TopMenu = () => {
 };
 
 export default TopMenu;
+
+export const rerenderTopMenu = () => {
+  renderTopMenu();
+};

--- a/src/pages/Editor/TopMenu/index.tsx
+++ b/src/pages/Editor/TopMenu/index.tsx
@@ -10,27 +10,11 @@ import {
 } from 'react-icons/fa';
 import useHistory from '@src/hooks/useHistory';
 import Tooltip from '@components/Tooltip';
-import { useHotkeys } from 'react-hotkeys-hook';
+import useMapHotkeys from '@src/pages/Editor/TopMenu/useMapHotkeys';
 
 const TopMenu = () => {
+  useMapHotkeys();
   const history = useHistory();
-
-  useHotkeys('cmd+z', (e: KeyboardEvent) => {
-    e.preventDefault();
-    history.undo();
-  });
-  useHotkeys('ctrl+z', (e: KeyboardEvent) => {
-    e.preventDefault();
-    history.undo();
-  });
-  useHotkeys('cmd+y', (e: KeyboardEvent) => {
-    e.preventDefault();
-    history.redo();
-  });
-  useHotkeys('ctrl+y', (e: KeyboardEvent) => {
-    e.preventDefault();
-    history.undo();
-  });
 
   return (
     <S.MenuContainer>
@@ -51,13 +35,13 @@ const TopMenu = () => {
         <S.ScreenSize>W: 1452 PX</S.ScreenSize>
       </S.DevicesCol>
       <S.PublishCol>
-        <Tooltip content={history.undoIsDisabled ? 'Nothing to undo' : 'Undo'}>
-          <S.UndoRedo off={history.undoIsDisabled} onClick={history.undo}>
+        <Tooltip content={!history.canUndo ? 'Nothing to undo' : 'Undo'}>
+          <S.UndoRedo off={!history.canUndo} onClick={history.undo}>
             <FaUndoAlt />
           </S.UndoRedo>
         </Tooltip>
-        <Tooltip content={history.redoIsDisabled ? 'Nothing to redo' : 'Redo'}>
-          <S.UndoRedo off={history.redoIsDisabled} onClick={history.redo}>
+        <Tooltip content={!history.canRedo ? 'Nothing to redo' : 'Redo'}>
+          <S.UndoRedo off={!history.canRedo} onClick={history.redo}>
             <FaRedoAlt />
           </S.UndoRedo>
         </Tooltip>

--- a/src/pages/Editor/TopMenu/useMapHotkeys.ts
+++ b/src/pages/Editor/TopMenu/useMapHotkeys.ts
@@ -1,0 +1,25 @@
+import useHistory from '@src/hooks/useHistory';
+import { useHotkeys } from 'react-hotkeys-hook';
+
+const useMapHotkeys = () => {
+  const history = useHistory();
+
+  useHotkeys('cmd+z', (e: KeyboardEvent) => {
+    e.preventDefault();
+    if (history.canUndo) history.undo();
+  });
+  useHotkeys('ctrl+z', (e: KeyboardEvent) => {
+    e.preventDefault();
+    if (history.canUndo) history.undo();
+  });
+  useHotkeys('cmd+y', (e: KeyboardEvent) => {
+    e.preventDefault();
+    if (history.canRedo) history.redo();
+  });
+  useHotkeys('ctrl+y', (e: KeyboardEvent) => {
+    e.preventDefault();
+    if (history.canRedo) history.undo();
+  });
+};
+
+export default useMapHotkeys;


### PR DESCRIPTION
Currently, the undo-redo feature uses two arrays to keep track of previous states. We can try to reduce the memory usage by 50% by only storing only last state.