### PR TITLE
Feat: use styled component for responsive styles

### DIFF
--- a/src/common/current.ts
+++ b/src/common/current.ts
@@ -1,4 +1,4 @@
-import { ElementType, ParentType } from '@src/types';
+import { ElementType, ParentType, ScreenWidthType } from '@src/types';
 
 let node: any = null;
 let parent: ParentType = null;
@@ -12,6 +12,7 @@ let editAble = false;
 let isResizingWidth = false;
 let isResizingHeight = false;
 let currentUuid = '';
+let screenWidth: ScreenWidthType = '100%';
 
 export const current = {
   getElement: () => element,
@@ -61,5 +62,11 @@ export const current = {
   },
   set uuid(uuid: string | undefined) {
     currentUuid = uuid || '';
+  },
+  get screenWidth() {
+    return screenWidth;
+  },
+  set screenWidth(width: ScreenWidthType) {
+    screenWidth = width || '100%';
   },
 };

--- a/src/common/current.ts
+++ b/src/common/current.ts
@@ -1,4 +1,6 @@
 import { ElementType, ParentType, ScreenWidthType } from '@src/types';
+import global from '@src/global';
+import { MEASUREMENT } from '@src/global/variables';
 
 let node: any = null;
 let parent: ParentType = null;
@@ -66,7 +68,19 @@ export const current = {
   get screenWidth() {
     return screenWidth;
   },
+  get isDesktopScreen() {
+    return screenWidth === MEASUREMENT.DESKTOP_SCREEN;
+  },
+  get isTabletScreen() {
+    return screenWidth === MEASUREMENT.TABLET_SCREEN;
+  },
+  get isMobileScreen() {
+    return screenWidth === MEASUREMENT.MOBILE_SCREEN;
+  },
   set screenWidth(width: ScreenWidthType) {
     screenWidth = width || '100%';
+  },
+  get isEditMode() {
+    return global.getMode() === 'edit';
   },
 };

--- a/src/components/PropsEditor/controls/shared/index.ts
+++ b/src/components/PropsEditor/controls/shared/index.ts
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { getColor } from '@src/theme';
-import { COLORS } from '@src/global/StyleVariables';
+import { COLORS } from '@src/global/variables';
 
 export const Container = styled.div`
   display: flex;

--- a/src/components/PropsEditor/index.tsx
+++ b/src/components/PropsEditor/index.tsx
@@ -18,7 +18,7 @@ const PropsEditor = () => {
   const initialSelection = data.get() as ElementType;
   const currentElement: ElementType =
     current.getElement() || initialSelection || {};
-  const { props = {} }: any = currentElement;
+  const props = populatePropsBasedOnScreenWidth(currentElement);
 
   const setProp = (
     newProp: any = {},
@@ -110,3 +110,16 @@ const PropsEditor = () => {
 };
 
 export default PropsEditor;
+
+const populatePropsBasedOnScreenWidth = (element: ElementType) => {
+  const { mdScreen, smScreen, ...otherProps }: any = element.props;
+  let props = otherProps;
+  if (current.isTabletScreen) {
+    props = { ...props, ...mdScreen };
+  }
+  if (current.isMobileScreen) {
+    props = { ...props, ...mdScreen, ...smScreen };
+  }
+
+  return props;
+};

--- a/src/global/element.ts
+++ b/src/global/element.ts
@@ -23,14 +23,36 @@ export const updateElementProp = (
 
   if (undoAble) {
     history.capture(() => {
-      element.props = { ...element.props, ...newProp };
+      _updateElementProp(element, newProp);
     });
   } else {
-    element.props = { ...element.props, ...newProp };
+    _updateElementProp(element, newProp);
   }
 
   data.persistToLocalStorage();
   return element;
+};
+
+const _updateElementProp = (element: ElementType | null, newProp: any) => {
+  if (!element) return element;
+
+  if (current.isTabletScreen) {
+    element.props['mdScreen'] = {
+      ...element.props?.mdScreen,
+      ...newProp,
+    };
+  }
+
+  if (current.isMobileScreen) {
+    element.props['smScreen'] = {
+      ...element.props?.smScreen,
+      ...newProp,
+    };
+  }
+
+  if (current.isDesktopScreen) {
+    element.props = { ...element.props, ...newProp };
+  }
 };
 
 export const addChildElement = (

--- a/src/global/variables.ts
+++ b/src/global/variables.ts
@@ -1,7 +1,18 @@
+import { ScreenWidthType } from '@src/types';
+
 export const MEASUREMENT = {
   LEFT_PANEL_WIDTH: () => '250px',
   RIGHT_PANEL_WIDTH: () => '250px',
   CANVAS_WIDTH: () => 'calc(100% - 500px)',
+  get DESKTOP_SCREEN() {
+    return '100%' as ScreenWidthType;
+  },
+  get TABLET_SCREEN() {
+    return '768px' as ScreenWidthType;
+  },
+  get MOBILE_SCREEN() {
+    return '450px' as ScreenWidthType;
+  },
 };
 
 export const COLORS = {

--- a/src/hooks/useEditor.ts
+++ b/src/hooks/useEditor.ts
@@ -1,0 +1,6 @@
+import { useContext } from 'react';
+import PageData from '@src/context';
+
+export const useEditor = () => {
+  return useContext(PageData);
+};

--- a/src/pages/Editor/ElementContainer/styles.ts
+++ b/src/pages/Editor/ElementContainer/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { COLORS } from '@src/global/StyleVariables';
+import { COLORS } from '@src/global/variables';
 
 export const ElementsWrapper = styled.div`
   background-color: #404040;

--- a/src/pages/Editor/Navigator/index.tsx
+++ b/src/pages/Editor/Navigator/index.tsx
@@ -66,7 +66,6 @@ const ElementsTree = ({
   );
 
   useEffect(() => {
-    setClosedElements(elementWrapper.map((e) => e.element.id));
     setClosedElements((closedElements) =>
       closedElements.filter((id) => !isChildSelected(id))
     );

--- a/src/pages/Editor/Navigator/styles.ts
+++ b/src/pages/Editor/Navigator/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { COLORS } from '@src/global/StyleVariables';
+import { COLORS } from '@src/global/variables';
 
 export const NavigationContainer = styled.div`
   display: flex;

--- a/src/pages/Editor/TopMenu/ScreenWidthPicker/index.tsx
+++ b/src/pages/Editor/TopMenu/ScreenWidthPicker/index.tsx
@@ -1,0 +1,41 @@
+import * as S from './styles';
+import { FaDesktop, FaMobileAlt, FaTabletAlt } from 'react-icons/fa';
+import { useEditor } from '@src/hooks/useEditor';
+import { current } from '@src/common/current';
+import { ScreenWidthType } from '@src/types';
+import { MEASUREMENT } from '@src/global/variables';
+
+const ScreenWidthPicker = () => {
+  const { DESKTOP_SCREEN, MOBILE_SCREEN, TABLET_SCREEN } = MEASUREMENT;
+  const renderEditor = useEditor();
+
+  const handleSelect = (screenWidth: ScreenWidthType = '100%') => {
+    current.screenWidth = screenWidth;
+    renderEditor();
+  };
+  return (
+    <>
+      <S.DeviceScreens
+        selected={current.screenWidth === DESKTOP_SCREEN}
+        onClick={() => handleSelect(DESKTOP_SCREEN)}
+      >
+        <FaDesktop />
+      </S.DeviceScreens>
+      <S.DeviceScreens
+        selected={current.screenWidth === TABLET_SCREEN}
+        onClick={() => handleSelect(TABLET_SCREEN)}
+      >
+        <FaTabletAlt />
+      </S.DeviceScreens>
+      <S.DeviceScreens
+        selected={current.screenWidth === MOBILE_SCREEN}
+        onClick={() => handleSelect(MOBILE_SCREEN)}
+      >
+        <FaMobileAlt />
+      </S.DeviceScreens>
+      <S.ScreenSize>W: 1452 PX</S.ScreenSize>
+    </>
+  );
+};
+
+export default ScreenWidthPicker;

--- a/src/pages/Editor/TopMenu/ScreenWidthPicker/styles.ts
+++ b/src/pages/Editor/TopMenu/ScreenWidthPicker/styles.ts
@@ -1,0 +1,32 @@
+import styled from 'styled-components';
+import { COLORS } from '@src/global/variables';
+
+export const DeviceScreens = styled.div<{ selected?: boolean }>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  background-color: ${(props) =>
+    props.selected ? COLORS.INPUT_BACKGROUND : 'inherit'};
+  padding: 0px;
+  height: 100%;
+  width: 40px;
+  color: white;
+  font-size: 20px;
+  cursor: pointer;
+  border-right: 1px solid ${COLORS.INPUT_BACKGROUND};
+`;
+
+export const ScreenSize = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent;
+  border: none;
+  padding: 10px;
+  font-size: 13px;
+  color: white;
+  height: 100%;
+  border-right: 1px solid rgba(0, 0, 0, 0.76);
+`;

--- a/src/pages/Editor/TopMenu/UndoRedo/index.tsx
+++ b/src/pages/Editor/TopMenu/UndoRedo/index.tsx
@@ -1,5 +1,5 @@
 import Tooltip from '@components/Tooltip';
-import * as S from '@src/pages/Editor/TopMenu/styles';
+import * as S from './styles';
 import { FaRedoAlt, FaUndoAlt } from 'react-icons/fa';
 import useHistory from '@src/hooks/useHistory';
 import { useHotkeys } from 'react-hotkeys-hook';

--- a/src/pages/Editor/TopMenu/UndoRedo/styles.ts
+++ b/src/pages/Editor/TopMenu/UndoRedo/styles.ts
@@ -1,0 +1,17 @@
+import styled from 'styled-components';
+
+export const UndoRedo = styled.button<{ off: boolean }>`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  background-color: transparent;
+  border: none;
+  padding: 4px 7px;
+  color: ${(props) => (props.off ? 'grey' : '#dad9d9')};
+  cursor: ${(props) => (props.off ? 'not-allowed' : 'pointer')};
+
+  &:hover {
+    color: ${(props) => (props.off ? 'grey' : 'white')};
+  }
+`;

--- a/src/pages/Editor/TopMenu/index.tsx
+++ b/src/pages/Editor/TopMenu/index.tsx
@@ -1,12 +1,7 @@
 import * as S from './styles';
-import {
-  FaDesktop,
-  FaTabletAlt,
-  FaMobileAlt,
-  FaEye,
-  FaRocket,
-} from 'react-icons/fa';
+import { FaEye, FaRocket } from 'react-icons/fa';
 import UndoRedo from '@src/pages/Editor/TopMenu/UndoRedo';
+import ScreenWidthPicker from '@src/pages/Editor/TopMenu/ScreenWidthPicker';
 
 const TopMenu = () => {
   return (
@@ -16,16 +11,7 @@ const TopMenu = () => {
         <S.PageTitle>Page: Home</S.PageTitle>
       </S.HomeCol>
       <S.DevicesCol>
-        <S.DeviceScreens selected={true}>
-          <FaDesktop />
-        </S.DeviceScreens>
-        <S.DeviceScreens>
-          <FaTabletAlt />
-        </S.DeviceScreens>
-        <S.DeviceScreens>
-          <FaMobileAlt />
-        </S.DeviceScreens>
-        <S.ScreenSize>W: 1452 PX</S.ScreenSize>
+        <ScreenWidthPicker />
       </S.DevicesCol>
       <S.PublishCol>
         <UndoRedo />

--- a/src/pages/Editor/TopMenu/styles.ts
+++ b/src/pages/Editor/TopMenu/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { MEASUREMENT } from '@src/global/StyleVariables';
+import { MEASUREMENT } from '@src/global/variables';
 
 export const MenuContainer = styled.div`
   background-color: #404040;
@@ -39,21 +39,6 @@ export const PageTitle = styled.div`
   line-height: 30px;
   padding: 5px;
   font-size: 14px;
-`;
-
-export const DeviceScreens = styled.div<{ selected?: boolean }>`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  background-color: ${(props) => (props.selected ? 'black' : 'inherit')};
-  padding: 0px;
-  height: 100%;
-  width: 40px;
-  color: white;
-  font-size: 20px;
-  cursor: pointer;
-  border-right: 1px solid rgba(0, 0, 0, 0.76);
 `;
 
 export const HomeCol = styled.div`
@@ -124,34 +109,4 @@ export const PreviewButton = styled.button`
   &:hover {
     background-color: white;
   }
-`;
-
-export const UndoRedo = styled.button<{ off: boolean }>`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  background-color: transparent;
-  border: none;
-  padding: 4px 7px;
-  color: ${(props) => (props.off ? 'grey' : '#dad9d9')};
-  cursor: ${(props) => (props.off ? 'not-allowed' : 'pointer')};
-
-  &:hover {
-    color: ${(props) => (props.off ? 'grey' : 'white')};
-  }
-`;
-
-export const ScreenSize = styled.div`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  background-color: transparent;
-  border: none;
-  padding: 10px;
-  font-size: 13px;
-  color: white;
-  height: 100%;
-  border-right: 1px solid rgba(0, 0, 0, 0.76);
 `;

--- a/src/pages/Editor/index.tsx
+++ b/src/pages/Editor/index.tsx
@@ -10,6 +10,7 @@ import Tabs, { ActiveTabType } from '@src/pages/Editor/Tabs';
 import TabContent from '@src/pages/Editor/Tabs/TabContent';
 import TopMenu from '@src/pages/Editor/TopMenu';
 import { useRender } from '@src/hooks';
+import { current } from '@src/common/current';
 
 export default function Editor() {
   console.log('renders editor');
@@ -30,7 +31,9 @@ export default function Editor() {
           <TabContent activeTab={activeTab} />
         </S.LeftPanel>
         <S.Canvas id="canvas" className="editor">
-          <Render element={data.get()} parent={null} />
+          <S.Wrapper width={current.screenWidth}>
+            <Render element={data.get()} parent={null} />
+          </S.Wrapper>
         </S.Canvas>
         <S.RightPanel>
           <PropsEditor />

--- a/src/pages/Editor/styles.ts
+++ b/src/pages/Editor/styles.ts
@@ -1,5 +1,5 @@
 import styled from 'styled-components';
-import { MEASUREMENT } from '@src/global/StyleVariables';
+import { COLORS, MEASUREMENT } from '@src/global/variables';
 
 export const EditorContainer = styled.div`
   display: flex;
@@ -10,9 +10,13 @@ export const EditorContainer = styled.div`
 `;
 
 export const Canvas = styled.div`
-  padding: 4px;
   width: ${MEASUREMENT.CANVAS_WIDTH};
   overflow: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  background-color: ${COLORS.INPUT_BACKGROUND};
 `;
 
 export const LeftPanel = styled.div`
@@ -29,4 +33,10 @@ export const RightPanel = styled.div`
   width: ${MEASUREMENT.RIGHT_PANEL_WIDTH};
   height: 100%;
   overflow: hidden;
+`;
+
+export const Wrapper = styled.div<{ width?: string }>`
+  width: ${({ width }) => width};
+  overflow-x: hidden;
+  transition: width 0.3s ease-in-out;
 `;

--- a/src/pages/Editor/withEditHandler/styles.ts
+++ b/src/pages/Editor/withEditHandler/styles.ts
@@ -1,0 +1,69 @@
+import styled from 'styled-components';
+import { current } from '@src/common/current';
+import { MEASUREMENT } from '@src/global/variables';
+
+export const getStyledHandler = () => {
+  return current.isEditMode ? HandlerOnEdit : HandlerOnPreview;
+};
+
+export const getStyledComponent = (Component: any) => styled(Component)`
+  ${({ styles, mdStyles, smStyles }) => {
+    if (current.isEditMode) {
+      return stylesOnEdit(styles, mdStyles, smStyles);
+    } else {
+      return StylesOnPreview(styles, mdStyles, smStyles);
+    }
+  }};
+`;
+
+const StylesOnPreview = (styles: any, mdStyles: any, smStyles: any) => {
+  return {
+    ...styles,
+    [`@media (max-width: ${MEASUREMENT.TABLET_SCREEN})`]: mdStyles,
+    [`@media (max-width: ${MEASUREMENT.MOBILE_SCREEN})`]: smStyles,
+  };
+};
+
+const stylesOnEdit = (styles: any, mdStyles: any, smStyles: any) => {
+  if (current.isTabletScreen) {
+    return mdStyles;
+  }
+  if (current.isMobileScreen) {
+    return smStyles;
+  }
+
+  return styles;
+};
+
+const HandlerOnEdit = styled.div<{
+  styles?: any;
+  mdStyles: any;
+  smStyles: any;
+}>`
+  ${({ styles, mdStyles, smStyles }) => {
+    if (current.isTabletScreen) {
+      return mdStyles;
+    }
+    if (current.isMobileScreen) {
+      return smStyles;
+    }
+
+    return styles;
+  }};
+`;
+
+const HandlerOnPreview = styled.div<{
+  styles?: any;
+  mdStyles: any;
+  smStyles: any;
+}>`
+  ${({ styles }) => styles || {}};
+
+  @media (min-width: ${MEASUREMENT.TABLET_SCREEN}) {
+    ${({ mdStyles }) => mdStyles};
+  }
+
+  @media (min-width: ${MEASUREMENT.MOBILE_SCREEN}) {
+    ${({ smStyles }) => smStyles};
+  }
+`;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,3 +51,5 @@ export type SpacingType = {
   bottom: number;
   unit: string;
 };
+
+export type ScreenWidthType = '100%' | '768px' | '450px';


### PR DESCRIPTION
This PR is to enable responsive styles based on different screen sizes.

**Example**

Desktop:
![Screen Shot 2022-11-14 at 22 56 48](https://user-images.githubusercontent.com/32300655/201692209-cc6904c0-9eca-4758-8406-c39c811a089e.png)

Tablet:
![Screen Shot 2022-11-14 at 22 57 03](https://user-images.githubusercontent.com/32300655/201692240-b67af3b1-339c-468e-9bca-edd67a57aaec.png)

Mobile:
![Screen Shot 2022-11-14 at 22 57 16](https://user-images.githubusercontent.com/32300655/201692268-0915bbe1-ed3c-4e79-8150-71baa918017c.png)
